### PR TITLE
scopes.md: from my understanding, this should be deff* for executable.

### DIFF
--- a/doc/scopes.md
+++ b/doc/scopes.md
@@ -41,9 +41,9 @@ Some of these functions are aliased, because they appear particularly useful:
 * `==?` aliases `defv`, i.e. value definition without optimization guarantees
 * `==` aliases `defvst`, i.e. value definition with static and type constness
 * `==:` aliases `defvd`, i.e. value definition with deep constness
-* `=*?` aliases `defv`, i.e. executable definition without optimization guarantees
-* `=*` aliases `defvst`, i.e. executable definition with static and type constness
-* `=*:` aliases `defvd`, i.e. executable definition with deep constness
+* `=*?` aliases `deff`, i.e. executable definition without optimization guarantees
+* `=*` aliases `deffst`, i.e. executable definition with static and type constness
+* `=*:` aliases `deffd`, i.e. executable definition with deep constness
 
 The value associated with a name can be updated using the `=` function. It takes a name to update and the new value from the stack.
 


### PR DESCRIPTION
`defv*` is already defined in the three preceding lines. If my assumption is wrong, please add an explanation why it is `defv*` and not `deff*` ;-)
